### PR TITLE
Refactor participants in simulation

### DIFF
--- a/src/pages/Simulation/components/ActionCardsEntry.js
+++ b/src/pages/Simulation/components/ActionCardsEntry.js
@@ -33,15 +33,14 @@ const ActionCardsEntry = ({
   const dispatch = useDispatch();
 
   const nextRound = useSelector((state) => selectNextRound(state.workshop));
-  const workshopParticipants = useSelector(
-    (state) => state.workshop.result.participants
-  );
-  const [selectedParticipantId, setSelectedParticipantId] = useState(
-    workshopParticipants ? workshopParticipants[0] : -1
-  );
+
   const participantsEntity = useSelector(
     (state) => state.workshop.entities.participants
   );
+  const [selectedParticipantId, setSelectedParticipantId] = useState(
+    participantsEntity ? Object.keys(participantsEntity)[0] : -1
+  );
+
   const handleParticipantSelect = (id) => {
     console.log('handleParticipantSelect', id);
     setSelectedParticipantId(id);
@@ -205,7 +204,6 @@ const ActionCardsEntry = ({
               <h4>{t('common.participants')}</h4>
               <ParticipantsTable
                 round={currentRound}
-                workshopParticipants={workshopParticipants}
                 participantsEntity={participantsEntity}
                 individualChoices={currentIndividualChoices}
                 selectedParticipantId={selectedParticipantId}

--- a/src/pages/Simulation/components/ParticipantsTable.js
+++ b/src/pages/Simulation/components/ParticipantsTable.js
@@ -9,7 +9,6 @@ import {
 
 const ParticipantsTable = ({
   round,
-  workshopParticipants,
   participantsEntity,
   individualChoices,
   selectedParticipantId,
@@ -45,9 +44,8 @@ const ParticipantsTable = ({
 
   return (
     <div>
-      {workshopParticipants &&
-        participantsEntity &&
-        workshopParticipants.map((participantId) => {
+      {participantsEntity &&
+        Object.keys(participantsEntity).map((participantId) => {
           // might make sense to simplify the component by taking the two functions outside
           const { firstName, lastName } = participantsEntity[participantId];
           const numberOfSelectedActions = getNumberOfChosenActionCards(

--- a/src/pages/Simulation/index.js
+++ b/src/pages/Simulation/index.js
@@ -1,28 +1,27 @@
-import React, { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import styled from 'styled-components';
-import { Button, Container, Row, Col, Spinner, Card } from 'react-bootstrap';
-import { useTranslation } from 'react-i18next';
-import footprintData from '../../utils/mocks/footprintData';
-import {
-  footprintDataToGraph,
-  currentRound,
-} from '../../selectors/footprintSelectors';
 import './components/simulationPage.css';
-import { useWorkshop } from '../../hooks/workshop';
-import NavbarWorkshop from '../../components/NavbarWorkshop';
-import FootprintGraphType from './components/FootprintGraphType';
-import EvolutionCarbon from './components/EvolutionCarbon';
-import CommonModal from '../../components/CommonModal';
+import { Button, Card, Col, Container, Row, Spinner } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  currentRound,
+  footprintDataToGraph,
+} from '../../selectors/footprintSelectors';
 import { startRound } from '../../actions/workshop';
-import NewRoundModalForm from './components/NewRoundModalForm';
+import { useTranslation } from 'react-i18next';
+import { useWorkshop } from '../../hooks/workshop';
 import ActionCardsEntry from './components/ActionCardsEntry';
+import CommonModal from '../../components/CommonModal';
+import EvolutionCarbon from './components/EvolutionCarbon';
+import FootprintGraphType from './components/FootprintGraphType';
+import NavbarWorkshop from '../../components/NavbarWorkshop';
+import NewRoundModalForm from './components/NewRoundModalForm';
+import React, { useEffect, useState } from 'react';
+import footprintData from '../../utils/mocks/footprintData';
+import styled from 'styled-components';
+
 const Simulation = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const { entities, result, isLoading, loadError } = useWorkshop(1);
-  console.log('entities', entities);
-  console.log('result', result);
+  
   const currentRound = useSelector(
     (state) =>
       state.workshop &&
@@ -53,13 +52,13 @@ const Simulation = () => {
   const [showEntryOfActionCards, setShowEntryOfActionCards] = useState(false);
   const handleCloseEntryOfActionCards = () => setShowEntryOfActionCards(false);
   return (
-    <React.Fragment>
+    <>
       <NavbarWorkshop
         avatarUrl="https://img.icons8.com/doodle/48/000000/user.png"
         firstName="Xavier"
         role="Animateur"
       />
-      <h4 class="workshop_title">{workshopTitle}</h4>
+      <h4 className="workshop_title">{workshopTitle}</h4>
       <h5>
         Nous sommes en ...{'  '}
         <span style={{ fontSize: 25, fontWeight: 'bold' }}>
@@ -75,33 +74,27 @@ const Simulation = () => {
               {t('common.nextRound')}
             </Button>
           </Row>
-          {loadError && <p>{t('common.loadError')}</p>}
-          {isLoading && (
-            <Spinner animation="border" className="pt-3 mx-auto mt-5" />
-          )}
-          {!isLoading && (
-            <Row style={{ height: '100vh' }}>
-              <Col sm={12} md={7} className="graph-col">
-                <Container className="graph-card">
-                  <h4>
-                    Evolution du CO<span style={{ fontSize: '14px' }}>2</span>{' '}
-                    par personne
-                  </h4>
-                  <EvolutionCarbon data={evolutionData} />
-                </Container>
-              </Col>
-              <Col sm={12} md={5} className="graph-col">
-                <Container className="graph-card">
-                  <h4> Moyenne nationale </h4>
-                  <FootprintGraphType type="globalAverage" />
-                </Container>
-                <Container className="graph-card">
-                  <h4> Les participants </h4>
-                  <FootprintGraphType type="participantsAverage" />
-                </Container>
-              </Col>
-            </Row>
-          )}
+          <Row style={{ height: '100vh' }}>
+            <Col sm={12} md={7} className="graph-col">
+              <Container className="graph-card">
+                <h4>
+                  Evolution du CO<span style={{ fontSize: '14px' }}>2</span>{' '}
+                  par personne
+                </h4>
+                <EvolutionCarbon data={evolutionData} />
+              </Container>
+            </Col>
+            <Col sm={12} md={5} className="graph-col">
+              <Container className="graph-card">
+                <h4> Moyenne nationale </h4>
+                <FootprintGraphType type="globalAverage" />
+              </Container>
+              <Container className="graph-card">
+                <h4> Les participants </h4>
+                <FootprintGraphType type="participantsAverage" />
+              </Container>
+            </Col>
+          </Row>
         </Container>
       </StyledSimulation>
       <CommonModal
@@ -126,7 +119,7 @@ const Simulation = () => {
           roundActionCardType={roundActionCardType}
         />
       </CommonModal>
-    </React.Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
Au lieu de charger workshop avec 
```const { entities, result, isLoading, loadError } = useWorkshop(1);```
on recupere object workshop dans le store directement. On assume qu'il était déjà chargé par avant - e.g. quand on click "entrer dans le workshop" sur l'ecran workshops.

En plus, maintenant le code utilise seulement object `participants` dans `workshop.entities` et pas `participants` dans `workshop.result`. 