### PR TITLE
Card chosen multiple times

### DIFF
--- a/src/components/ActionCardItem.js
+++ b/src/components/ActionCardItem.js
@@ -22,9 +22,25 @@ const ActionCardItem = ({
   sector,
   active,
   checked,
+  previousChoices,
   cost,
   handleChange,
 }) => {
+  const indicators = [];
+  const nIndicators = previousChoices + (checked ? 1 : 0);
+  if (nIndicators > 0) {
+    [...Array(nIndicators).keys()].forEach((key) =>
+      indicators.push(
+        <img
+          src={require('../assets/GreenIndicator.svg')}
+          width={sizeGreen}
+          height={sizeGreen}
+          key={`indicator${key}`}
+        />
+      )
+    );
+  }
+
   return (
     <StyledItem
       checked={checked}
@@ -42,12 +58,8 @@ const ActionCardItem = ({
           <div className="col p-1">{text.toLowerCase()}</div>
           <div className="col-auto pl-0 pr-1 d-flex align-items-end align-self-stretch flex-column">
             <div>
-              {checked ? (
-                <img
-                  src={require('../assets/GreenIndicator.svg')}
-                  width={sizeGreen}
-                  height={sizeGreen}
-                />
+              {nIndicators ? (
+                indicators
               ) : (
                 <img
                   src={require('../assets/WhiteIndicator.svg')}
@@ -68,12 +80,8 @@ const ActionCardItem = ({
           </div>
           <div className="col-7 pl-0 pr-1 d-flex align-items-end align-self-stretch flex-column">
             <div>
-              {checked ? (
-                <img
-                  src={require('../assets/GreenIndicator.svg')}
-                  width={sizeGreen}
-                  height={sizeGreen}
-                />
+              {nIndicators ? (
+                indicators
               ) : (
                 <img
                   src={require('../assets/WhiteIndicator.svg')}

--- a/src/components/ActionCardItem.js
+++ b/src/components/ActionCardItem.js
@@ -26,20 +26,18 @@ const ActionCardItem = ({
   cost,
   handleChange,
 }) => {
-  const indicators = [];
   const nIndicators = previousChoices + (checked ? 1 : 0);
-  if (nIndicators > 0) {
-    [...Array(nIndicators).keys()].forEach((key) =>
-      indicators.push(
-        <img
-          src={require('../assets/GreenIndicator.svg')}
-          width={sizeGreen}
-          height={sizeGreen}
-          key={`indicator${key}`}
-        />
-      )
-    );
-  }
+  const indicators =
+    nIndicators > 0
+      ? [...Array(nIndicators).keys()].map((key) => (
+          <img
+            src={require('../assets/GreenIndicator.svg')}
+            width={sizeGreen}
+            height={sizeGreen}
+            key={`indicator${key}`}
+          />
+        ))
+      : [];
 
   return (
     <StyledItem

--- a/src/pages/Simulation/components/ActionCardsForm.js
+++ b/src/pages/Simulation/components/ActionCardsForm.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
-import { Col, Form, Button } from 'react-bootstrap';
+import { Button, Col, Form } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import ActionCardItem from '../../../components/ActionCardItem';
-import { COLORS } from '../../../vars';
 
 import {
   selectCheckedCollectiveActionCardsBatchIdsFromRounds,
@@ -25,20 +23,7 @@ const ActionCardsForm = ({
   const actionCardsEntity = useSelector(
     (state) => state.workshop.entities.actionCards
   );
-  const roundConfigEntity = useSelector(
-    (state) => state.workshop.entities.roundConfig
-  );
-  const actionCardsBatchIdsFromRounds = useSelector((state) =>
-    actionCardType === 'individual'
-      ? selectCheckedIndividualActionCardsBatchIdsFromRounds(state.workshop)
-      : selectCheckedCollectiveActionCardsBatchIdsFromRounds(state.workshop)
-  );
-  // initial active == expanded lot is the last lot of the current round
-  const [activeBatch, setActiveBatch] = useState(
-    roundConfigEntity[
-      Object.keys(roundConfigEntity).slice(-1)[0]
-    ].actionCardBatchIds.slice(-1)[0]
-  );
+
   function compareName(a, b) {
     if (actionCardBatchesEntity[a].name < actionCardBatchesEntity[b].name) {
       return -1;
@@ -48,61 +33,65 @@ const ActionCardsForm = ({
     }
     return 0;
   }
+  const actionCardsBatchIdsFromRounds = useSelector((state) =>
+    (actionCardType === 'individual'
+      ? selectCheckedIndividualActionCardsBatchIdsFromRounds(state.workshop)
+      : selectCheckedCollectiveActionCardsBatchIdsFromRounds(state.workshop)
+    ).sort(compareName)
+  );
+  // initial active == expanded lot is the last lot of the current round
+  const [activeBatch, setActiveBatch] = useState(
+    actionCardsBatchIdsFromRounds.slice(-1)[0]
+  );
+
   return (
-    // <Form noValidate>
-      <Form.Row>
-        {
-          actionCardsBatchIdsFromRounds
-            .sort(compareName)
-            .map((actionCardBatchId) => {
-              if (!actionCardBatchesEntity[actionCardBatchId]) {
-                return <></>;
-              }
-              const {
-                name: actionCardBatchName,
-                actionCardIds,
-              } = actionCardBatchesEntity[actionCardBatchId];
-              return (
-                <Form.Group
-                  as={Col}
-                  sm={actionCardBatchId === activeBatch ? '5' : '2'}
-                  key={actionCardBatchId}
-                >
-                  <BatchBadge
-                    text={actionCardBatchName}
-                    active={actionCardBatchId === activeBatch}
-                    handleClick={() => setActiveBatch(actionCardBatchId)}
-                  />
-                  {actionCardIds.map((actionCardId) => {
-                    const {
-                      name: actionCardName,
-                      cardNumber,
-                      sector,
-                    } = actionCardsEntity[actionCardId];
-                    return (
-                      <ActionCardItem
-                        key={actionCardId}
-                        id={cardNumber}
-                        cardNumber={cardNumber}
-                        text={actionCardName}
-                        sector={sector}
-                        category={actionCardsEntity[actionCardId].subCategory}
-                        active={actionCardBatchId === activeBatch}
-                        checked={handleCheckedActionCard(actionCardId)}
-                        cost={actionCardsEntity[actionCardId].cost}
-                        handleChange={() =>
-                          handleCardActionSelectionChange(actionCardId)
-                        }
-                      />
-                    );
-                  })}
-                </Form.Group>
-              );
-            })
-          // )
+    <Form.Row>
+      {actionCardsBatchIdsFromRounds.map((actionCardBatchId) => {
+        if (!actionCardBatchesEntity[actionCardBatchId]) {
+          return <></>;
         }
-      </Form.Row>
-    // </Form>
+        const {
+          name: actionCardBatchName,
+          actionCardIds,
+        } = actionCardBatchesEntity[actionCardBatchId];
+        return (
+          <Form.Group
+            as={Col}
+            sm={actionCardBatchId === activeBatch ? '5' : '2'}
+            key={actionCardBatchId}
+          >
+            <BatchBadge
+              text={actionCardBatchName}
+              active={actionCardBatchId === activeBatch}
+              handleClick={() => setActiveBatch(actionCardBatchId)}
+            />
+            {actionCardIds.map((actionCardId) => {
+              const {
+                name: actionCardName,
+                cardNumber,
+                sector,
+              } = actionCardsEntity[actionCardId];
+              return (
+                <ActionCardItem
+                  key={actionCardId}
+                  id={cardNumber}
+                  cardNumber={cardNumber}
+                  text={actionCardName}
+                  sector={sector}
+                  category={actionCardsEntity[actionCardId].subCategory}
+                  active={actionCardBatchId === activeBatch}
+                  checked={handleCheckedActionCard(actionCardId)}
+                  cost={actionCardsEntity[actionCardId].cost}
+                  handleChange={() =>
+                    handleCardActionSelectionChange(actionCardId)
+                  }
+                />
+              );
+            })}
+          </Form.Group>
+        );
+      })}
+    </Form.Row>
   );
 };
 

--- a/src/pages/Simulation/components/ActionCardsForm.js
+++ b/src/pages/Simulation/components/ActionCardsForm.js
@@ -13,7 +13,8 @@ import {
 const ActionCardsForm = ({
   // handleSubmit,
   handleCardActionSelectionChange,
-  handleCheckedActionCard,
+  isCheckedActionCard,
+  numberOfPreviousChoices,
   actionCardType,
 }) => {
   const { t } = useTranslation();
@@ -80,7 +81,8 @@ const ActionCardsForm = ({
                   sector={sector}
                   category={actionCardsEntity[actionCardId].subCategory}
                   active={actionCardBatchId === activeBatch}
-                  checked={handleCheckedActionCard(actionCardId)}
+                  checked={isCheckedActionCard(actionCardId)}
+                  previousChoices={numberOfPreviousChoices(actionCardId)}
                   cost={actionCardsEntity[actionCardId].cost}
                   handleChange={() =>
                     handleCardActionSelectionChange(actionCardId)

--- a/src/selectors/workshopSelector.spec.js
+++ b/src/selectors/workshopSelector.spec.js
@@ -1,16 +1,14 @@
 import {
+  getAllIndividualChoicesForParticipant,
   getCostOfChosenActionCards,
   getInitRoundBudget,
   getNumberOfChosenActionCards,
-  isIndividualActionCardTakenForParticipant,
   selectCarbonFootprintsEntityForCurrentRound,
   selectCarbonFootprintsEntityForRound,
   selectCheckedCollectiveActionCardsBatchIdsFromRounds,
   selectCheckedIndividualActionCardsBatchIdsFromRounds,
   selectCitizenCarbonFootprintsEntityForCurrentRound,
   selectCitizenCarbonFootprintsEntityForRound,
-  selectIndividualChoiceIdsForParticipant,
-  selectIndividualChoicesForParticipant,
   selectIsWorkshopReadyForInitialization,
   selectNextRound,
 } from './workshopSelector';
@@ -46,7 +44,7 @@ const individualChoicesEntity = {
   },
   '2026-1': {
     participantId: 1,
-    actionCardIds: [4],
+    actionCardIds: [4, 2],
   },
   '2026-2': {
     participantId: 2,
@@ -87,42 +85,19 @@ describe('Workshop selector', () => {
       expect(result).toEqual(2023);
     });
   });
-  describe('Test isIndividualActionCardTakenForParticipant', () => {
-    describe('Participant 1', () => {
-      const participantIndividualActionCards = isIndividualActionCardTakenForParticipant(
-        workshop,
-        1
-      );
-      it('should return true if participant has taken the given action', () => {
-        const result = participantIndividualActionCards(2);
-        expect(result).toBe(true);
-      });
-      it('should return false if participant has not taken the given action', () => {
-        const result = participantIndividualActionCards(3);
-        expect(result).toBe(false);
-      });
-    });
-    it("should return false if participant does'nt exists", () => {
-      const result = isIndividualActionCardTakenForParticipant(workshop, 0)(3);
-      expect(result).toBe(false);
-    });
-    it('should return false if there is no parameter', () => {
-      const result = isIndividualActionCardTakenForParticipant()();
-      expect(result).toBe(false);
-    });
-  });
-  describe('Test selectIndividualChoicesForParticipant', () => {
+
+  describe('Test getAllIndividualChoicesForParticipant', () => {
     it('should return array of individual actions for participant 1', () => {
-      const result = selectIndividualChoicesForParticipant(
+      const result = getAllIndividualChoicesForParticipant(
         1,
         roundConfigEntity,
         individualChoicesEntity
       );
-      const expected = [2, 4];
-      expect(result).toEqual(expected);
+      const expected = [2, 2, 4];
+      expect(result.sort()).toEqual(expected.sort());
     });
     it('should return array of individual actions for participant 2', () => {
-      const result = selectIndividualChoicesForParticipant(
+      const result = getAllIndividualChoicesForParticipant(
         2,
         roundConfigEntity,
         individualChoicesEntity
@@ -131,7 +106,7 @@ describe('Workshop selector', () => {
       expect(result).toEqual(expected);
     });
     it('should return empty array for inexisting participant (3)', () => {
-      const result = selectIndividualChoicesForParticipant(
+      const result = getAllIndividualChoicesForParticipant(
         3,
         roundConfigEntity,
         individualChoicesEntity
@@ -140,29 +115,7 @@ describe('Workshop selector', () => {
       expect(result).toEqual(expected);
     });
     it('should return empty array if there is no param', () => {
-      const result = selectIndividualChoicesForParticipant();
-      const expected = [];
-      expect(result).toEqual(expected);
-    });
-  });
-  describe('Test selectIndividualChoicesIdsForParticipant', () => {
-    it('should return array of individual actions for participant 1', () => {
-      const result = selectIndividualChoiceIdsForParticipant(workshop, 1);
-      const expected = [2, 4];
-      expect(result).toEqual(expected);
-    });
-    it('should return array of individual actions for participant 2', () => {
-      const result = selectIndividualChoiceIdsForParticipant(workshop, 2);
-      const expected = [3, 4, 6];
-      expect(result).toEqual(expected);
-    });
-    it('should return empty array for inexisting participant (3)', () => {
-      const result = selectIndividualChoiceIdsForParticipant(workshop, 3);
-      const expected = [];
-      expect(result).toEqual(expected);
-    });
-    it('should return empty array if there is no param', () => {
-      const result = selectIndividualChoiceIdsForParticipant();
+      const result = getAllIndividualChoicesForParticipant();
       const expected = [];
       expect(result).toEqual(expected);
     });
@@ -174,9 +127,11 @@ describe('Workshop selector', () => {
       participantIds,
       actionCardsEntity
     );
-    // remaing budget for participant 1 = (2020.budget + 2026.budget) - (2.cost + 4.cost) = 10 - 6 = 4
-    expect(roundBudget[1]).toEqual(4);
-    // cost for participant 2 = (2020.budget + 2026.budget) - (3.cost + 4.cost + 6.cost) = 10 - 6 = 4
+    // remaing budget for participant 1 =
+    // (2020.budget + 2026.budget) - (2.cost + 4.cost + 2.cost) = 10 - 6 = 1
+    expect(roundBudget[1]).toEqual(1);
+    // cost for participant 2 =
+    // (2020.budget + 2026.budget) - (3.cost + 4.cost + 6.cost) = 10 - 6 = 4
     expect(roundBudget[2]).toEqual(4);
   });
 


### PR DESCRIPTION
Adds the display of choices from previous rounds as the number of green indicators. The choices of the current round are marked by an additional green indicator + darker color.
![image](https://user-images.githubusercontent.com/11229250/88909617-a1679b00-d25b-11ea-8e62-d483a904f7c6.png)

Apart from the visual part, includes refactoring of a number of functions in `workshopSelector.js`
- removes near duplicate (?) functions `selectIndividualChoiceIdsForParticipant` and `selectIndividualChoicesForParticipant` 
- removes unused now function `isIndividualActionCardTakenForParticipant`
- updates tests accordingly

Other:
- updates the choice of default active batch (always the last one) which was broken after the order of batches began to be determined by alphabetical order of batch names (I'm not sure this sorting is a very good idea, might be something to re-check in the future). 