### PR TITLE
Bugs/#62

### DIFF
--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Spinner } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+
+const Loading = ({ isLoading, error, children }) => {
+  const t = useTranslation();
+  if (error) {
+    return (
+      <div className="d-flex justify-content-center">
+        <p>{t('common.loadError')}</p>
+      </div>
+    );
+  }
+  if (isLoading) {
+    return (
+      <div className="d-flex justify-content-center">
+        <Spinner animation="border" className="pt-3 mx-auto mt-5" />
+      </div>
+    );
+  }
+  return children;
+};
+
+export default Loading;

--- a/src/hooks/workshop.js
+++ b/src/hooks/workshop.js
@@ -15,115 +15,132 @@ export const useWorkshop = (requestedWorkshopId) => {
   const localWorkshop = useSelector((state) => state.workshop);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const cloudWorkshop = await getWorkshop({
-          workshopId: requestedWorkshopId,
-        });
-        const cloudWorkshopUpdatedAt = new Date(cloudWorkshop.result.updatedAt);
-        if (mounted.current) {
-          if (localWorkshop === null || !localWorkshop.result) {
-            // eslint-disable-next-line no-console
-            console.info(
-              'Use case 1: No local workshop: Store cloudWorkshop locally'
-            );
-            // No local workshop: Store cloudWorkshop locally
-            dispatch(workshopRetrieved(cloudWorkshop));
-          } else {
-            const {
-              isSynchronized,
-              result: { id: localWorkshopId, updatedAt },
-            } = localWorkshop;
-            const localWorkshopUpdatedAt = new Date(updatedAt);
-
-            if (localWorkshopId === requestedWorkshopId) {
-              // The local workshop is the same as the requested workshop
-              if (
-                cloudWorkshopUpdatedAt.getTime() ===
-                localWorkshopUpdatedAt.getTime()
-              ) {
-                // eslint-disable-next-line no-console
-                console.info(
-                  'Use case 2: the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...'
-                );
-                // the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...
-                dispatch(workshopRetrieved(cloudWorkshop));
-              } else if (localWorkshopUpdatedAt < cloudWorkshopUpdatedAt) {
-                // The localWorkshop is older than the cloudWorkshop
-                if (!isSynchronized) {
-                  // eslint-disable-next-line no-console
-                  console.info(
-                    'Use case 3: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace localWorkshop with the requestWorkshop'
-                  );
-                  // The localWorkshop has been modified locally or has never been synchronized:
-                  // We need to refect modification to cloud version
-                  // Send modif to cloud
-                  await updateWorkshopApi({
-                    workshopId: localWorkshopId,
-                    data: localWorkshop,
-                  });
-                  // Then replace localWorkshop with the requestWorkshop
-                  dispatch(workshopRetrieved(cloudWorkshop));
-                } else {
-                  // eslint-disable-next-line no-console
-                  console.info(
-                    'Use case 4: The cloudWorkshop has been modified by someone else. Update the localWorkshop with the cloudWorkshop'
-                  );
-                  // The cloudWorkshop has been modified by someone else
-                  // Update the localWorkshop with the cloudWorkshop
-                  dispatch(workshopRetrieved(cloudWorkshop));
-                }
-              } else {
-                // Can't happen: The updatedAt field is never modified locally
-                // eslint-disable-next-line no-console
-                console.info(
-                  "Use case 5: Can't happen: The updatedAt field is never modified locally"
-                );
-                // eslint-disable-next-line no-console
-                console.error(
-                  `Error: local workshop ${localWorkshopId} has been modified at ${localWorkshopUpdatedAt} \n
-                  which is more recent than the cloud workshop version modified at ${cloudWorkshopUpdatedAt}`
-                );
-              }
-            }
-            // The local workshop is different from the requested workshop
-            else if (!isSynchronized) {
+    if (
+      !localWorkshop ||
+      !localWorkshop.result ||
+      localWorkshop.result.id !== requestedWorkshopId
+    ) {
+      const load = async () => {
+        try {
+          const cloudWorkshop = await getWorkshop({
+            workshopId: requestedWorkshopId,
+          });
+          const cloudWorkshopUpdatedAt = new Date(
+            cloudWorkshop.result.updatedAt
+          );
+          if (mounted.current) {
+            if (localWorkshop === null || !localWorkshop.result) {
               // eslint-disable-next-line no-console
               console.info(
-                'Use case 6: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace it with the requestWorkshop'
+                'Use case 1: No local workshop: Store cloudWorkshop locally'
               );
-              // The localWorkshop has been modified locally or has never been synchronized:
-              // We need to refect modification to cloud version
-              // Send modif to cloud
-              await updateWorkshopApi({
-                workshopId: localWorkshopId,
-                data: localWorkshop,
-              });
-              // Then replace it with the requestWorkshop
+              // No local workshop: Store cloudWorkshop locally
               dispatch(workshopRetrieved(cloudWorkshop));
             } else {
-              // eslint-disable-next-line no-console
-              console.log(
-                'Use case 7: The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop'
-              );
-              // The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop
-              dispatch(workshopRetrieved(cloudWorkshop));
+              const {
+                isSynchronized,
+                result: { id: localWorkshopId, updatedAt },
+              } = localWorkshop;
+              const localWorkshopUpdatedAt = new Date(updatedAt);
+
+              if (localWorkshopId === requestedWorkshopId) {
+                // The local workshop is the same as the requested workshop
+                if (
+                  cloudWorkshopUpdatedAt.getTime() ===
+                  localWorkshopUpdatedAt.getTime()
+                ) {
+                  // eslint-disable-next-line no-console
+                  console.info(
+                    'Use case 2: the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...'
+                  );
+                  // eslint-disable-next-line max-len
+                  // the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...
+                  dispatch(workshopRetrieved(cloudWorkshop));
+                } else if (localWorkshopUpdatedAt < cloudWorkshopUpdatedAt) {
+                  // The localWorkshop is older than the cloudWorkshop
+                  if (!isSynchronized) {
+                    // eslint-disable-next-line no-console
+                    console.info(
+                      'Use case 3: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace localWorkshop with the requestWorkshop'
+                    );
+                    // eslint-disable-next-line max-len
+                    // The localWorkshop has been modified locally or has never been synchronized:
+                    // We need to refect modification to cloud version
+                    // Send modif to cloud
+                    await updateWorkshopApi({
+                      workshopId: localWorkshopId,
+                      data: localWorkshop,
+                    });
+                    // Then replace localWorkshop with the requestWorkshop
+                    dispatch(workshopRetrieved(cloudWorkshop));
+                  } else {
+                    // eslint-disable-next-line no-console
+                    console.info(
+                      'Use case 4: The cloudWorkshop has been modified by someone else. Update the localWorkshop with the cloudWorkshop'
+                    );
+                    // The cloudWorkshop has been modified by someone else
+                    // Update the localWorkshop with the cloudWorkshop
+                    dispatch(workshopRetrieved(cloudWorkshop));
+                  }
+                } else {
+                  // Can't happen: The updatedAt field is never modified locally
+                  // eslint-disable-next-line no-console
+                  console.info(
+                    "Use case 5: Can't happen: The updatedAt field is never modified locally"
+                  );
+                  // eslint-disable-next-line no-console
+                  console.error(
+                    `Error: local workshop ${localWorkshopId} has been modified at ${localWorkshopUpdatedAt} \n
+                  which is more recent than the cloud workshop version modified at ${cloudWorkshopUpdatedAt}`
+                  );
+                }
+              }
+              // The local workshop is different from the requested workshop
+              else if (!isSynchronized) {
+                // eslint-disable-next-line no-console
+                console.info(
+                  'Use case 6: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace it with the requestWorkshop'
+                );
+                // eslint-disable-next-line max-len
+                // The localWorkshop has been modified locally or has never been synchronized:
+                // We need to refect modification to cloud version
+                // Send modif to cloud
+                await updateWorkshopApi({
+                  workshopId: localWorkshopId,
+                  data: localWorkshop,
+                });
+                // Then replace it with the requestWorkshop
+                dispatch(workshopRetrieved(cloudWorkshop));
+              } else {
+                // eslint-disable-next-line no-console
+                console.log(
+                  'Use case 7: The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop'
+                );
+                // eslint-disable-next-line max-len
+                // The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop
+                dispatch(workshopRetrieved(cloudWorkshop));
+              }
             }
           }
+          return cloudWorkshop;
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(e);
+          if (mounted.current) {
+            dispatch(workshopLoadError(e));
+          }
+          return null;
         }
-        return cloudWorkshop;
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
-        if (mounted.current) {
-          dispatch(workshopLoadError(e));
-        }
-        return null;
-      }
-    };
-    mounted.current = true;
-    dispatch(retrieveWorkshop());
-    load();
+      };
+      mounted.current = true;
+      dispatch(retrieveWorkshop());
+      load();
+    } else {
+      // eslint-disable-next-line no-console
+      console.info(
+        'Use case 0: the local workshop id is equals to the requested workshop id. Just return'
+      );
+    }
     return () => {
       mounted.current = false;
     };

--- a/src/hooks/workshop.js
+++ b/src/hooks/workshop.js
@@ -7,12 +7,13 @@ import {
   workshopLoadError,
   workshopRetrieved,
 } from '../actions/workshop';
+import { selectCurrentWorkshop } from '../selectors/workshopSelector';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useWorkshop = (workshopId) => {
   const mounted = useRef(false);
   const dispatch = useDispatch();
-  const workshop = useSelector((state) => state.workshop);
+  const workshop = useSelector(selectCurrentWorkshop);
   useEffect(() => {
     if (!workshop || !workshop.result || workshop.result.id !== workshopId) {
       // eslint-disable-next-line no-console

--- a/src/hooks/workshop.js
+++ b/src/hooks/workshop.js
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useRef } from 'react';
 
-import { getWorkshop, updateWorkshopApi } from '../utils/api';
+import { getWorkshop } from '../utils/api';
 import {
   retrieveWorkshop,
   workshopLoadError,
@@ -9,123 +9,24 @@ import {
 } from '../actions/workshop';
 
 // eslint-disable-next-line import/prefer-default-export
-export const useWorkshop = (requestedWorkshopId) => {
+export const useWorkshop = (workshopId) => {
   const mounted = useRef(false);
   const dispatch = useDispatch();
-  const localWorkshop = useSelector((state) => state.workshop);
-
+  const workshop = useSelector((state) => state.workshop);
   useEffect(() => {
-    if (
-      !localWorkshop ||
-      !localWorkshop.result ||
-      localWorkshop.result.id !== requestedWorkshopId
-    ) {
+    if (!workshop || !workshop.result || workshop.result.id !== workshopId) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'Use case 1: No local workshop or local workshop id is different from the requested workshop id: Fetch the requested workshop'
+      );
       const load = async () => {
         try {
-          const cloudWorkshop = await getWorkshop({
-            workshopId: requestedWorkshopId,
-          });
-          const cloudWorkshopUpdatedAt = new Date(
-            cloudWorkshop.result.updatedAt
-          );
+          const result = await getWorkshop({ workshopId });
           if (mounted.current) {
-            if (localWorkshop === null || !localWorkshop.result) {
-              // eslint-disable-next-line no-console
-              console.info(
-                'Use case 1: No local workshop: Store cloudWorkshop locally'
-              );
-              // No local workshop: Store cloudWorkshop locally
-              dispatch(workshopRetrieved(cloudWorkshop));
-            } else {
-              const {
-                isSynchronized,
-                result: { id: localWorkshopId, updatedAt },
-              } = localWorkshop;
-              const localWorkshopUpdatedAt = new Date(updatedAt);
-
-              if (localWorkshopId === requestedWorkshopId) {
-                // The local workshop is the same as the requested workshop
-                if (
-                  cloudWorkshopUpdatedAt.getTime() ===
-                  localWorkshopUpdatedAt.getTime()
-                ) {
-                  // eslint-disable-next-line no-console
-                  console.info(
-                    'Use case 2: the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...'
-                  );
-                  // eslint-disable-next-line max-len
-                  // the local workshop is synchronized with the cloud workshop: In therory, no need to update it locally. but do it in the case where ...
-                  dispatch(workshopRetrieved(cloudWorkshop));
-                } else if (localWorkshopUpdatedAt < cloudWorkshopUpdatedAt) {
-                  // The localWorkshop is older than the cloudWorkshop
-                  if (!isSynchronized) {
-                    // eslint-disable-next-line no-console
-                    console.info(
-                      'Use case 3: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace localWorkshop with the requestWorkshop'
-                    );
-                    // eslint-disable-next-line max-len
-                    // The localWorkshop has been modified locally or has never been synchronized:
-                    // We need to refect modification to cloud version
-                    // Send modif to cloud
-                    await updateWorkshopApi({
-                      workshopId: localWorkshopId,
-                      data: localWorkshop,
-                    });
-                    // Then replace localWorkshop with the requestWorkshop
-                    dispatch(workshopRetrieved(cloudWorkshop));
-                  } else {
-                    // eslint-disable-next-line no-console
-                    console.info(
-                      'Use case 4: The cloudWorkshop has been modified by someone else. Update the localWorkshop with the cloudWorkshop'
-                    );
-                    // The cloudWorkshop has been modified by someone else
-                    // Update the localWorkshop with the cloudWorkshop
-                    dispatch(workshopRetrieved(cloudWorkshop));
-                  }
-                } else {
-                  // Can't happen: The updatedAt field is never modified locally
-                  // eslint-disable-next-line no-console
-                  console.info(
-                    "Use case 5: Can't happen: The updatedAt field is never modified locally"
-                  );
-                  // eslint-disable-next-line no-console
-                  console.error(
-                    `Error: local workshop ${localWorkshopId} has been modified at ${localWorkshopUpdatedAt} \n
-                  which is more recent than the cloud workshop version modified at ${cloudWorkshopUpdatedAt}`
-                  );
-                }
-              }
-              // The local workshop is different from the requested workshop
-              else if (!isSynchronized) {
-                // eslint-disable-next-line no-console
-                console.info(
-                  'Use case 6: The localWorkshop has been modified locally or has never been synchronized: We need to refect modification to cloud version. Then replace it with the requestWorkshop'
-                );
-                // eslint-disable-next-line max-len
-                // The localWorkshop has been modified locally or has never been synchronized:
-                // We need to refect modification to cloud version
-                // Send modif to cloud
-                await updateWorkshopApi({
-                  workshopId: localWorkshopId,
-                  data: localWorkshop,
-                });
-                // Then replace it with the requestWorkshop
-                dispatch(workshopRetrieved(cloudWorkshop));
-              } else {
-                // eslint-disable-next-line no-console
-                console.log(
-                  'Use case 7: The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop'
-                );
-                // eslint-disable-next-line max-len
-                // The local workshop is synchronized with the cloud. We can replace it with the requestWorkshop
-                dispatch(workshopRetrieved(cloudWorkshop));
-              }
-            }
+            dispatch(workshopRetrieved(result));
           }
-          return cloudWorkshop;
+          return result;
         } catch (e) {
-          // eslint-disable-next-line no-console
-          console.error(e);
           if (mounted.current) {
             dispatch(workshopLoadError(e));
           }
@@ -138,12 +39,12 @@ export const useWorkshop = (requestedWorkshopId) => {
     } else {
       // eslint-disable-next-line no-console
       console.info(
-        'Use case 0: the local workshop id is equals to the requested workshop id. Just return'
+        'Use case 2: the local workshop id is equals to the requested workshop id. Just return'
       );
     }
     return () => {
       mounted.current = false;
     };
-  }, [dispatch, requestedWorkshopId]);
-  return localWorkshop;
+  }, [dispatch, workshopId]);
+  return workshop;
 };

--- a/src/pages/Participants/index.js
+++ b/src/pages/Participants/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions */
 import Papa from 'papaparse';
 import React, { useState } from 'react';
-import { Card, Container, Modal } from 'react-bootstrap';
+import { Card, Container } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
@@ -12,6 +12,7 @@ import AddParticipantModalForm from './components/AddParticipantModalForm';
 import CardHeader from '../../components/CardHeader';
 import CommonModal from '../../components/CommonModal';
 import FootprintGraph from '../Simulation/components/FootprintGraph';
+import Loading from '../../components/Loading';
 import PrimaryButton from '../../components/PrimaryButton';
 import computeCarbonVariables from '../../reducers/utils/bufferCarbonVariables';
 import {
@@ -59,7 +60,7 @@ const ManageParticipants = ({
     params: { workshopId },
   },
 }) => {
-  const workshop = useWorkshop(workshopId);
+  const { error, isLoading } = useWorkshop(workshopId);
   const isWorkshopReadyForInitialization = useSelector(
     selectIsWorkshopReadyForInitialization
   );
@@ -228,73 +229,78 @@ const ManageParticipants = ({
     });
 
   return (
-    <Container>
-      <h2 className="workshop-title">{workshopTitle}</h2>
-      <Card className="p-5 border-light shadow-sm" style={{ borderRadius: 10 }}>
-        <CardHeader>
-          <h3>{t('manageParticipants.title')}</h3>
-          <AddNewButton
-            onClick={() => {
-              setShowAddParticipantModal(true);
-            }}
-          >
-            {t('manageParticipants.addNew')}
-          </AddNewButton>
-        </CardHeader>
-        <hr />
-
-        <div className="container">
-          <ParticipantsHeader />
-          {participantItems}
-          <hr />
-        </div>
-        <div style={{ textAlign: 'center' }}>
-          {isSynchronized && workshopStatus === 'created' && (
-            <PrimaryButton
-              onClick={() => dispatch(startWorkshop(2020))}
-              disabled={!isWorkshopReadyForInitialization}
+    <Loading error={error} isLoading={isLoading}>
+      <Container>
+        <h2 className="workshop-title">{workshopTitle}</h2>
+        <Card
+          className="p-5 border-light shadow-sm"
+          style={{ borderRadius: 10 }}
+        >
+          <CardHeader>
+            <h3>{t('manageParticipants.title')}</h3>
+            <AddNewButton
+              onClick={() => {
+                setShowAddParticipantModal(true);
+              }}
             >
-              {t('common.launchSimulation')}
-            </PrimaryButton>
-          )}
-          {workshopStatus === 'ongoing' && (
-            <Link to={`/workshop/${workshopId}/simulation`}>
-              <PrimaryButton>{t('common.continueSimulation')}</PrimaryButton>
-            </Link>
-          )}
-        </div>
-      </Card>
-      {showBC && (
+              {t('manageParticipants.addNew')}
+            </AddNewButton>
+          </CardHeader>
+          <hr />
+
+          <div className="container">
+            <ParticipantsHeader />
+            {participantItems}
+            <hr />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            {isSynchronized && workshopStatus === 'created' && (
+              <PrimaryButton
+                onClick={() => dispatch(startWorkshop(2020))}
+                disabled={!isWorkshopReadyForInitialization}
+              >
+                {t('common.launchSimulation')}
+              </PrimaryButton>
+            )}
+            {workshopStatus === 'ongoing' && (
+              <Link to={`/workshop/${workshopId}/simulation`}>
+                <PrimaryButton>{t('common.continueSimulation')}</PrimaryButton>
+              </Link>
+            )}
+          </div>
+        </Card>
+        {showBC && (
+          <CommonModal
+            size="md"
+            centered
+            show={showBC}
+            handleClose={() => {
+              setShowBC(false);
+            }}
+            title={t('manageParticipants.titleBCmodal', {
+              name: participants[footprintToShow.id].firstName,
+            })}
+          >
+            <h5>
+              {t('manageParticipants.totalBC')} {footprintToShow.total}{' '}
+              {t('manageParticipants.unitBC')}
+            </h5>
+            <FootprintGraph footprint={footprintToShow.footprint} />
+          </CommonModal>
+        )}
         <CommonModal
           size="md"
           centered
-          show={showBC}
+          show={showAddParticipantModal}
           handleClose={() => {
-            setShowBC(false);
+            setShowAddParticipantModal(false);
           }}
-          title={t('manageParticipants.titleBCmodal', {
-            name: participants[footprintToShow.id].firstName,
-          })}
+          title={t('manageParticipants.titleAddNewModal')}
         >
-          <h5>
-            {t('manageParticipants.totalBC')} {footprintToShow.total}{' '}
-            {t('manageParticipants.unitBC')}
-          </h5>
-          <FootprintGraph footprint={footprintToShow.footprint} />
+          <AddParticipantModalForm t={t} handleSubmit={handleAddParticipant} />
         </CommonModal>
-      )}
-      <CommonModal
-        size="md"
-        centered
-        show={showAddParticipantModal}
-        handleClose={() => {
-          setShowAddParticipantModal(false);
-        }}
-        title={t('manageParticipants.titleAddNewModal')}
-      >
-        <AddParticipantModalForm t={t} handleSubmit={handleAddParticipant} />
-      </CommonModal>
-    </Container>
+      </Container>
+    </Loading>
   );
 };
 

--- a/src/pages/Participants/index.js
+++ b/src/pages/Participants/index.js
@@ -255,12 +255,14 @@ const ManageParticipants = ({
           </div>
           <div style={{ textAlign: 'center' }}>
             {isSynchronized && workshopStatus === 'created' && (
-              <PrimaryButton
-                onClick={() => dispatch(startWorkshop(2020))}
-                disabled={!isWorkshopReadyForInitialization}
-              >
-                {t('common.launchSimulation')}
-              </PrimaryButton>
+              <Link to={`/workshop/${workshopId}/simulation`}>
+                <PrimaryButton
+                  onClick={() => dispatch(startWorkshop(2020))}
+                  disabled={!isWorkshopReadyForInitialization}
+                >
+                  {t('common.launchSimulation')}
+                </PrimaryButton>
+              </Link>
             )}
             {workshopStatus === 'ongoing' && (
               <Link to={`/workshop/${workshopId}/simulation`}>

--- a/src/pages/Participants/index.js
+++ b/src/pages/Participants/index.js
@@ -224,7 +224,7 @@ const ManageParticipants = ({
           currentPersonaId={p.personaId}
           handleShowBC={handleShowBC}
           handleSendForm={handleSendForm}
-          disabled={workshop.result.status !== 'created'}
+          disabled={workshopStatus !== 'created'}
         />
       );
     });

--- a/src/pages/Simulation/index.js
+++ b/src/pages/Simulation/index.js
@@ -90,7 +90,7 @@ const Simulation = ({
         )}
       </div>
 
-      {currentRound && (
+      {!isLoading && currentRound && (
         <>
           <h2 className="workshop-title">{workshopTitle}</h2>
 

--- a/src/utils/api/index.js
+++ b/src/utils/api/index.js
@@ -60,6 +60,7 @@ export const updateWorkshopApi = ({ workshopId, data }) => {
   return handleFetch(`/workshops/${workshopId}`, {
     method: 'PUT',
     body: JSON.stringify(denormalizedWorkshop),
+    type: 'empty',
   });
 };
 


### PR DESCRIPTION
- Add a Loading component to centralize Loading mechanism and display
- Simplify and change workshop hook behaviour: If the requested workshopId is already in the redux store, then the workshop is not fetch. This new behaviour fixes and closes #62 
- Fix error message in the console when trying to parse PUT /workshop response (which is now empty)
- Do not display Workshop title when loading data in Simulation page
