### PR TITLE
Change workshop state when currentYear reaches endYear and do not save next rounds if workshop is ended

### DIFF
--- a/src/actions/workshop.spec.js
+++ b/src/actions/workshop.spec.js
@@ -1,0 +1,45 @@
+import { createStore } from 'redux';
+
+import reducers from '../reducers';
+import { endWorkshop } from './workshop';
+
+const onStoreChange = (store) => (expectationsFn) => (done) => {
+  store.subscribe(() => {
+    setTimeout(() => {
+      expectationsFn();
+      done();
+    }, 1000);
+  });
+};
+
+const assertStoreWasUpdatedWithExpectedData = (store) => (expected) => (
+  done
+) => {
+  onStoreChange(store)(() => {
+    expect(store.getState().workshop).toEqual(expected.workshop);
+  })(done);
+};
+
+describe('Workshop', () => {
+  describe('End Workshop', () => {
+    it('should set the workshop status to ended', (done) => {
+      const initState = {
+        workshop: {
+          result: {
+            status: 'ongoing',
+          },
+        },
+      };
+      const expected = {
+        workshop: {
+          result: {
+            status: 'ended',
+          },
+        },
+      };
+      const store = createStore(reducers, initState);
+      assertStoreWasUpdatedWithExpectedData(store)(expected)(done);
+      store.dispatch(endWorkshop());
+    });
+  });
+});

--- a/src/locales/fr/translation.js
+++ b/src/locales/fr/translation.js
@@ -101,6 +101,7 @@ export default {
     entryOfCollectiveActions: 'Saisie des actions collectives',
     entryOfIndividualActions: 'Saisie des actions individuelles',
     environmentalInitiatives: 'ECOGESTES',
+    extraRound: 'Tour supplémentaire',
     firstName: 'Prénom',
     food: 'Alimentation',
     home: 'Accueil',

--- a/src/pages/Simulation/components/NewRoundModalForm.js
+++ b/src/pages/Simulation/components/NewRoundModalForm.js
@@ -12,6 +12,7 @@ import {
   getDefaultRoundType,
   selectCheckedCollectiveActionCardsBatchIdsFromRounds,
   selectCheckedIndividualActionCardsBatchIdsFromRounds,
+  selectCurrentWorkshopInfo,
 } from '../../../selectors/workshopSelector';
 import {
   selectCollectiveBatches,
@@ -25,8 +26,8 @@ const budgetYearStyle = 'outline-secondary';
 
 const NewRoundModalForm = ({ handleSubmit }) => {
   const { t } = useTranslation();
-  const { currentYear, endYear, yearIncrement } = useSelector(
-    (state) => state.workshop.result
+  const { currentYear, endYear, yearIncrement, status } = useSelector(
+    selectCurrentWorkshopInfo
   );
   const actionCardsEntity = useSelector(
     (state) => state.workshop.entities.actionCards
@@ -184,7 +185,7 @@ const NewRoundModalForm = ({ handleSubmit }) => {
                   <Button
                     variant={budgetYearStyle}
                     onClick={() => {
-                      if (values.targetedYear < endYear) {
+                      if (status === 'ended' || values.targetedYear < endYear) {
                         setFieldValue('targetedYear', values.targetedYear + 1);
                       }
                     }}

--- a/src/pages/Simulation/index.js
+++ b/src/pages/Simulation/index.js
@@ -20,6 +20,8 @@ import {
   selectCarbonFootprintsEntityForCurrentRound,
   selectCitizenCarbonFootprintsEntityForCurrentRound,
   selectCurrentRound,
+  selectCurrentRoundActionCardType,
+  selectCurrentWorkshopInfo,
   selectFootprintStructure,
 } from '../../selectors/workshopSelector';
 import { startRound } from '../../actions/workshop';
@@ -51,18 +53,10 @@ const Simulation = ({
     currentCitizenFootprints,
     footprintStructure
   );
-  const workshopTitle = useSelector(
-    (state) => state.workshop.result && state.workshop.result.name
+  const { name: workshopTitle, status } = useSelector(
+    selectCurrentWorkshopInfo
   );
-  const roundActionCardType = useSelector(
-    (state) =>
-      currentRound &&
-      state.workshop &&
-      state.workshop.entities &&
-      state.workshop.entities.roundConfig &&
-      state.workshop.entities.roundConfig[currentRound] &&
-      state.workshop.entities.roundConfig[currentRound].actionCardType
-  );
+  const roundActionCardType = useSelector(selectCurrentRoundActionCardType);
   // NewRoundModal
   const [showNewRoundModal, setShowNewRoundModal] = useState(false);
   const handleCloseNewRoundModal = () => setShowNewRoundModal(false);
@@ -105,7 +99,9 @@ const Simulation = ({
                   variant="primary"
                   onClick={handleShowNewRoundModal}
                 >
-                  {t('common.nextRound')}
+                  {status === 'ended'
+                    ? t('common.extraRound')
+                    : t('common.nextRound')}
                 </PrimaryButton>
               </CardHeader>
               {!isLoading && (

--- a/src/reducers/workshop.js
+++ b/src/reducers/workshop.js
@@ -15,6 +15,7 @@ import {
   COMPUTE_CARBON_VARIABLES,
   COMPUTE_FOOTPRINTS,
   COMPUTE_FOOTPRINTS_FOR_CITIZENS,
+  END_WORKSHOP,
   INIT_ROUND,
   INIT_WORKSHOP,
   PERSIST_WORKSHOP,
@@ -180,6 +181,15 @@ export default (state = initialState, action) => {
           status: 'ongoing',
           rounds: [year],
           currentYear: year,
+        },
+      };
+    }
+    case END_WORKSHOP: {
+      return {
+        ...state,
+        result: {
+          ...state.result,
+          status: 'ended',
         },
       };
     }

--- a/src/selectors/workshopSelector.js
+++ b/src/selectors/workshopSelector.js
@@ -99,6 +99,12 @@ export const selectNextRound = (state) => {
   return config ? config.targetedYear : null;
 };
 
+export const selectCurrentRoundActionCardType = (state) => {
+  const roundConfigEntity = selectRoundConfigEntity(state);
+  const currentRound = selectCurrentRound(state);
+  return pathOr(null, [currentRound, 'actionCardType'], roundConfigEntity);
+};
+
 export const selectIndividualRoundIds = (roundConfigEntity) =>
   Object.keys(roundConfigEntity).filter(
     (roundConfigId) =>


### PR DESCRIPTION
- Change workshop state when currentYear reaches endYear (endYear is configured in the backend with value 2050)
- Do not save next rounds if workshop is ended
- Change button label 'Prochain Tour' by 'Tour supplémentaire' when workshop is ended