### PR TITLE
display already selected batches in New Round popup

### DIFF
--- a/src/pages/Simulation/components/ActionCardsForm.js
+++ b/src/pages/Simulation/components/ActionCardsForm.js
@@ -35,8 +35,8 @@ const ActionCardsForm = ({
   }
   const actionCardsBatchIdsFromRounds = useSelector((state) =>
     (actionCardType === 'individual'
-      ? selectCheckedIndividualActionCardsBatchIdsFromRounds(state.workshop)
-      : selectCheckedCollectiveActionCardsBatchIdsFromRounds(state.workshop)
+      ? selectCheckedIndividualActionCardsBatchIdsFromRounds(state)
+      : selectCheckedCollectiveActionCardsBatchIdsFromRounds(state)
     ).sort(compareName)
   );
   // initial active == expanded lot is the last lot of the current round

--- a/src/pages/Simulation/components/NewRoundModalForm.js
+++ b/src/pages/Simulation/components/NewRoundModalForm.js
@@ -42,22 +42,16 @@ const NewRoundModalForm = ({ handleSubmit }) => {
   const actionCardsEntity = useSelector(
     (state) => state.workshop.entities.actionCards
   );
-  const individualActionCardBatches = useSelector((state) =>
-    selectIndividualBatches(state.workshop.entities.actionCardBatches)
-  );
-  const collectiveActionCardBatches = useSelector((state) =>
-    selectCollectiveBatches(state.workshop.entities.actionCardBatches)
-  );
-  const checkedIndividualActionCardsBatchIds = useSelector((state) =>
-    selectCheckedIndividualActionCardsBatchIdsFromRounds(state.workshop)
+  const individualActionCardBatches = useSelector(selectIndividualBatches);
+  const collectiveActionCardBatches = useSelector(selectCollectiveBatches);
+  const checkedIndividualActionCardsBatchIds = useSelector(
+    selectCheckedIndividualActionCardsBatchIdsFromRounds
   );
   // prev checked (to disable) array of batchIds
-  const checkedCollectiveActionCardsBatchIds = useSelector((state) =>
-    selectCheckedCollectiveActionCardsBatchIdsFromRounds(state.workshop)
+  const checkedCollectiveActionCardsBatchIds = useSelector(
+    selectCheckedCollectiveActionCardsBatchIdsFromRounds
   );
-  const defaultRoundType = useSelector((state) =>
-    getDefaultRoundType(state.workshop.entities.roundConfig, currentYear)
-  );
+  const defaultRoundType = useSelector(getDefaultRoundType);
 
   const defaultBatchPreChecked = (roundType) =>
     roundType === 'individual'

--- a/src/selectors/actionsSelector.js
+++ b/src/selectors/actionsSelector.js
@@ -1,18 +1,24 @@
-const selectBatchesByType = (actionCardBatches, type) =>
-  (actionCardBatches &&
-    Object.keys(actionCardBatches)
-      .filter((id) => actionCardBatches[id].type === type)
-      .reduce(
-        (accumulator, actionCardBatchId) => ({
-          ...accumulator,
-          [actionCardBatchId]: actionCardBatches[actionCardBatchId],
-        }),
-        {}
-      )) ||
-  {};
+import { selectActionCardBatchesEntity } from './workshopSelector';
 
-export const selectIndividualBatches = (actionCardBatches) =>
-  selectBatchesByType(actionCardBatches, 'individual');
+const selectBatchesByType = (state, type) => {
+  const actionCardBatches = selectActionCardBatchesEntity(state);
+  return (
+    (actionCardBatches &&
+      Object.keys(actionCardBatches)
+        .filter((id) => actionCardBatches[id].type === type)
+        .reduce(
+          (accumulator, actionCardBatchId) => ({
+            ...accumulator,
+            [actionCardBatchId]: actionCardBatches[actionCardBatchId],
+          }),
+          {}
+        )) ||
+    {}
+  );
+};
 
-export const selectCollectiveBatches = (actionCardBatches) =>
-  selectBatchesByType(actionCardBatches, 'collective');
+export const selectIndividualBatches = (state) =>
+  selectBatchesByType(state, 'individual');
+
+export const selectCollectiveBatches = (state) =>
+  selectBatchesByType(state, 'collective');

--- a/src/selectors/actionsSelector.spec.js
+++ b/src/selectors/actionsSelector.spec.js
@@ -75,28 +75,28 @@ describe('Workshop selectors', () => {
     },
   };
   const initState = {
-    entities: {
-      actionCards: {
-        ...actionCard1,
-        ...actionCard2,
-        ...actionCard3,
-        ...actionCard4,
-        ...actionCard5,
+    workshop: {
+      entities: {
+        actionCards: {
+          ...actionCard1,
+          ...actionCard2,
+          ...actionCard3,
+          ...actionCard4,
+          ...actionCard5,
+        },
+        actionCardBatches: {
+          ...actionCardBatch1,
+          ...actionCardBatch2,
+          ...actionCardBatch3,
+        },
       },
-      actionCardBatches: {
-        ...actionCardBatch1,
-        ...actionCardBatch2,
-        ...actionCardBatch3,
-      },
+      result: { model: { actionCardBatches: [1, 2, 3] } },
     },
-    result: { model: { actionCardBatches: [1, 2, 3] } },
   };
   describe('Select actions from batches', () => {
     describe('Individual batches', () => {
       it('should return individual batches', (done) => {
-        const individualBatches = selectIndividualBatches(
-          initState.entities.actionCardBatches
-        );
+        const individualBatches = selectIndividualBatches(initState);
         expect(individualBatches).toEqual({
           ...actionCardBatch1,
           ...actionCardBatch2,
@@ -111,9 +111,7 @@ describe('Workshop selectors', () => {
     });
     describe('Collective batches', () => {
       it('should return collective batches', (done) => {
-        const collectiveBatches = selectCollectiveBatches(
-          initState.entities.actionCardBatches
-        );
+        const collectiveBatches = selectCollectiveBatches(initState);
         expect(collectiveBatches).toEqual({
           ...actionCardBatch3,
         });

--- a/src/selectors/workshopSelector.spec.js
+++ b/src/selectors/workshopSelector.spec.js
@@ -174,13 +174,13 @@ describe('Workshop selector', () => {
   });
   it('should return already selected individual actionCardBatches', () => {
     const returnedActionCardsBatchIds = selectCheckedIndividualActionCardsBatchIdsFromRounds(
-      { entities: { roundConfig: roundConfigEntity } }
+      { workshop: { entities: { roundConfig: roundConfigEntity } } }
     );
     expect(returnedActionCardsBatchIds).toEqual(['1', '2']);
   });
   it('should return already selected collective actionCardBatches', () => {
     const returnedActionCardsBatchIds = selectCheckedCollectiveActionCardsBatchIdsFromRounds(
-      { entities: { roundConfig: roundConfigEntity } }
+      { workshop: { entities: { roundConfig: roundConfigEntity } } }
     );
     expect(returnedActionCardsBatchIds).toEqual(['10']);
   });
@@ -200,7 +200,13 @@ describe('Workshop selector', () => {
       },
     };
     const returnedActionCardsBatchIds = selectCheckedIndividualActionCardsBatchIdsFromRounds(
-      { entities: { roundConfig: roundConfigEntityWithNullActionCardBatchIds } }
+      {
+        workshop: {
+          entities: {
+            roundConfig: roundConfigEntityWithNullActionCardBatchIds,
+          },
+        },
+      }
     );
     expect(returnedActionCardsBatchIds).toEqual(['1']);
   });


### PR DESCRIPTION
Fix #138 : If I run a round, I choose a batch and validate. Then I leave the tour. Then I want to restart my turn, the choice of the batch that I had chosen during the previous manipulation 'no longer appears as selectable. This is confusing